### PR TITLE
fix: correct FORARTfeh to FORARTfe in exFAT wiki URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A customized+improved J. Bruce Fields' [openwrt-recording](https://github.com/bf
 
 :white_check_mark: [USB Class Compliant audio device](https://github.com/FORARTfe/hALSAmrec/wiki/USB-Class-Compliant-audio-devices) autoprobe;
 
-:white_check_mark: [exFAT](https://github.com/FORARTfeh/hALSAmrec/wiki/Why-exFAT-Was-Chosen-for-the-SD-Card-Recording-Partition) (SDcard) recording;
+:white_check_mark: [exFAT](https://github.com/FORARTfe/hALSAmrec/wiki/Why-exFAT-Was-Chosen-for-the-SD-Card-Recording-Partition) (SDcard) recording;
 
 :white_check_mark: remote - webcommand - start/stop/status/probe ([Home App for Android™](https://github.com/Domi04151309/HomeApp#readme)-compatible too);
 


### PR DESCRIPTION
Fixes issue #14 — correct typo in exFAT wiki URL (extra 'h' in organization name).

**Before:** https://github.com/FORARTfeh/hALSAmrec/wiki/Why-exFAT-Was-Chosen-for-the-SD-Card-Recording-Partition
**After:** https://github.com/FORARTfe/hALSAmrec/wiki/Why-exFAT-Was-Chosen-for-the-SD-Card-Recording-Partition

Surgical fix to the README.md exFAT link on line 11.